### PR TITLE
Remove token from ps list

### DIFF
--- a/qx
+++ b/qx
@@ -1,6 +1,29 @@
 #!/usr/bin/env node
 
+const path = require("path");
 require("./lib/qxcli");
+
+// sanatise process list parameter
+let args = [path.relative(process.cwd(), process.argv[1])]
+
+for (let i=2; i<process.argv.length; i++) {
+  let arg = process.argv[i]
+  if (arg === '--token' || arg === '-t') {
+    args.push.apply(args, [arg, '*****'])
+    i++
+  }
+  else if (arg.startsWith('--token=')) {
+    args.push('--token=*****')
+  }
+  else if (arg.startsWith('-t')) {
+    args.push('-t*****')
+  }
+  else {
+    args.push(arg)
+  }
+}
+
+process.title = args.join(" ")
 
 // main config
 var title = "qooxdoo command line interface";


### PR DESCRIPTION
A nit picker:

If we've secrets on the CLI as arguments, they can be seen in the 'ps' output for other users on the same system. This patch replaces the token by '*****' in order to make that a bit more secure.