### PR TITLE
Fix compile js

### DIFF
--- a/docs/compile-json.md
+++ b/docs/compile-json.md
@@ -194,6 +194,28 @@ TypeScript can be output by either using the `--typescript` option to `qx compil
 ```
 The TypeScript definition is output into `./source-output/qooxdoo.d.ts`
 
+## compile.js
+Configuration files do not support processes, job executions, or even macros - if you want to add basic processing (eg for macros), use a .js file to manipulate the data. 
+.js MUST return a function. This function MUST accept two arguments, one for the data (which will be null if there is no .json) and the second is the callback to call when complete; the callback takes an error object and the output configuration data.
+
+If you provide a .js file and there is also a .json, then it is loaded and parsed first. The function in the .js is called with the parsed data from the .json file as a parameter.
+
+Example:
+
+```
+function compile(data, callback) {
+	console.log('I'm here');	
+    let err = null;
+	callback(err, data);
+}
+```
+
+If err is not null loading of the config file is rejected.
+
+
+
+     
+
 
 
 

--- a/lib/qxcli/commands/Compile.js
+++ b/lib/qxcli/commands/Compile.js
@@ -255,10 +255,9 @@ qx.Class.define("qxcli.commands.Compile", {
     
     /**
      * Loads a configuration file from a .js or .json file; if you provide a .js
-     * file and there is also a .json, then it is loaded and parsed first, and if
-     * the .js file returns a Function then the function is called with the parsed
-     * data from the .json file as a parameter.
-     *
+     * file the file MUST return a function.
+     * If there is also a .json, then it is loaded and parsed first.
+     * 
      * The Function returned from a .js file MUST accept two arguments, one for the
      * data (which will be null if there is no .json) and the second is the callback
      * to call when complete; the callback takes an error object and the output

--- a/lib/qxcli/commands/Compile.js
+++ b/lib/qxcli/commands/Compile.js
@@ -298,7 +298,7 @@ qx.Class.define("qxcli.commands.Compile", {
           if (err.code != "ENOENT")
             throw new Error("Cannot load JSON from " + path + "on: " + err);
         }
-        return loadJs(path, null);
+        return loadJs(path, json);
       } else {
         return qxcli.commands.Compile.loadJson(path);
       }

--- a/lib/qxcli/commands/Compile.js
+++ b/lib/qxcli/commands/Compile.js
@@ -20,7 +20,6 @@ const {promisify} = require('util');
 
 const qx = require("qooxdoo");
 const qxcompiler = require('qxcompiler');
-const os = require('os');
 const fs = require('fs');
 const path = require('path');
 const process = require('process');
@@ -191,7 +190,7 @@ qx.Class.define("qxcli.commands.Compile", {
         }
       }
 
-      var parsedArgs = this.parseImpl(argv);
+      var parsedArgs = await this.parseImpl(argv);
       var config = {};
       var contribConfig = {};
       if (parsedArgs.config) {
@@ -223,7 +222,7 @@ qx.Class.define("qxcli.commands.Compile", {
      * @param argv
      * @return {Obj}
      */
-    parseImpl: function(argv) {
+    parseImpl: async function(argv) {
       let apps = [];
       let app = null;
       let result = {
@@ -234,7 +233,7 @@ qx.Class.define("qxcli.commands.Compile", {
         environment: {},
         applications: apps,
         libraries: argv.library||[],
-        config: argv.configFile||"compile.json",
+        config: argv.configFile||await qxcompiler.files.Utils.safeStat("compile.js")?"compile.js":"compile.json",
         continuous: argv.continuous,
         verbose: argv.verbose
       };


### PR DESCRIPTION
Fixed some issues with compile.js:

   - loaded config data was not delivered to function in compile.js
   - added documentation how to use compile.js
   - fixed api docu.
   - if compile.js is found in Project dir use this instead of using the compile.json. So must not add compile.js to the command line