### PR TITLE
Add project to node path

### DIFF
--- a/docs/compile-json.md
+++ b/docs/compile-json.md
@@ -194,6 +194,72 @@ TypeScript can be output by either using the `--typescript` option to `qx compil
 ```
 The TypeScript definition is output into `./source-output/qooxdoo.d.ts`
 
+## compile.js
+Configuration files do not support processes, job executions, or even macros - if you want to add basic processing (eg for macros), use a .js file to manipulate the data. 
+.js MUST return a function. This function MUST accept two arguments, one for the data (which will be null if there is no .json) and the second is the callback to call when complete; the callback takes an error object and the output configuration data.
+
+If you provide a .js file and there is also a .json, then it is loaded and parsed first. The function in the .js is called with the parsed data from the .json file as a parameter.
+
+### simple example:
+
+```
+function compile(data, callback) {
+	console.log('I'm here');	
+    let err = null;
+	callback(err, data);
+}
+```
+
+If err is not null loading of the config file is rejected.
+
+### How to add sass call for mobile projects:
+
+```
+async function compile(data, callback) {
+/**
+ * Adds sass support for current project.
+ * Needed for qx.mobile projects.
+ * 
+ * PreReqs:
+ *    - add dependency to project package.json: "runscript": "^1.3.0"
+ *    - run npm install in project dir.
+ *    - change test in sass call with your project name
+ *  
+ * @param {*} data       : config data from compile.json
+ * @param {*} callback   : callback for qxcli.  
+ */
+  debugger;
+  const runscript = require('runscript');
+  runScript = async function (cmd) {
+    return new Promise((resolve) => runscript(cmd, {
+        stdio: 'pipe'
+      })
+      .then(stdio => {
+        console.log('Run "%s"', cmd);
+        if (stdio.stdout)
+          console.log(err.stdio.stdout.toString());
+        if (stdio.stderr)
+          console.log(err.stdio.stderr.toString());
+        resolve();
+      })
+      .catch(err => {
+        console.error(err.toString());
+        if (err.stdio.stdout)
+          console.error(err.stdio.stdout.toString());
+        if (err.stdio.stderr)
+          console.error(err.stdio.stderr.toString());
+        resolve();
+      }));
+  }
+  await runScript('sass -C -t compressed -I ../qooxdoo/framework/source/resource/qx/mobile/scss -I ../qooxdoo/framework/source/resource/qx/scss --update source/theme/test/scss:source/resource/test/css');
+  callback(null, data);
+}
+```
+
+
+
+     
+
 
 
 

--- a/lib/qxcli/commands/Compile.js
+++ b/lib/qxcli/commands/Compile.js
@@ -31,6 +31,8 @@ const Gauge = require("gauge");
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
 
+require('app-module-path').addPath(process.cwd() + '/node_modules');
+
 require("./Command");
 
 /**

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/qooxdoo/qx-cli#readme",
   "dependencies": {
+    "app-module-path": "^2.2.0",
     "async": "^2.4.1",
     "chokidar": "^1.7.0",
     "download": "^6.0.0",


### PR DESCRIPTION
To load project specific node modules during compile process it is necesary to have the path to the local node_modules in the search path of node.
So it is possible to load a special node modul for compiling a special project.

For an example see compile-json.md.

There you get an description how to add sass support for mobile Projects.