### PR TITLE
add compile.json to compile.js to watch

### DIFF
--- a/lib/qxcli/Watch.js
+++ b/lib/qxcli/Watch.js
@@ -55,6 +55,8 @@ qx.Class.define("qxcli.Watch", {
       analyser.addListener("compiledClass", function() {
         this.__stats.classesCompiled++;
       }, this);
+      dirs.push("compile.json");
+      dirs.push("compile.js");
       analyser.getLibraries().forEach(function(lib) {
         var dir = path.join(lib.getRootDir(), lib.getSourcePath());
         dirs.push(dir);


### PR DESCRIPTION
solution for issue 17: `qx compile --watch` not watching important files