### PR TITLE
Add better API methods to get metadata on the current library

### DIFF
--- a/lib/qxcli/commands/Command.js
+++ b/lib/qxcli/commands/Command.js
@@ -150,9 +150,10 @@ qx.Class.define("qxcli.commands.Command", {
      */
     getQooxdooPath : async function(argv)
     {
-      const cfg_path = path.join(process.cwd(), 'compile.json');
-      let maker = await new qxcli.commands.Compile(argv).configure(cfg_path);
-      return maker.getAnalyser().getQooxdooPath();
+      return this.getUserQxPath(argv);
+      //const cfg_path = path.join(process.cwd(), 'compile.json');
+      //let maker = await new qxcli.commands.Compile(argv).configure(cfg_path);
+      //return maker.getAnalyser().getQooxdooPath();
     },
     
     /**

--- a/lib/qxcli/commands/Command.js
+++ b/lib/qxcli/commands/Command.js
@@ -18,11 +18,12 @@
 ************************************************************************ */
 
 const qx = require("qooxdoo");
-const fs = require('fs');
+const qxcompiler = require('qxcompiler');
 const process = require('process');
 const child_process = require('child_process');
 const path = require('upath');
 
+const fs = qxcompiler.utils.Promisify.fs;
 require("../Utils");
 
 /**
@@ -47,26 +48,43 @@ qx.Class.define("qxcli.commands.Command", {
      * working directory. A library is assumed if a Manifest.json file
      * exists. 
      * @throws {Error} Throws an error if no library can be found.
-     * @return {String} The absolute path to the library
+     * @return {Promise(String)} A promise that resolves with the absolute path to the library
      */ 
-    getLibraryPath: function(){ 
+    getLibraryPath: async function(){ 
       let libPath = process.cwd(); 
-      if ( ! fs.existsSync( path.join( libPath, "Manifest.json" ) ) ){
-        throw new Error( "Cannot find library - are you in the right directory?");
+      if ( ! await fs.existsAsync( path.join( libPath, "Manifest.json" ) ) ){
+        throw new Error( "Cannot find library path - are you in the right directory?");
       }
       return libPath;
     },
 
     /**
-     * Returns the content of a json file in the library as an object. 
-     * @param {String} Relative path of the file in the library
-     * @throws {Error} Throws if library cannot be found or file cannot be parsed.
-     * @return {Object}
+     * Returns the  path to the current application, depending on the current
+     * working directory. An application is assumed if a compile.json file
+     * exists. 
+     * @throws {Error} Throws an error if no application can be found.
+     * @return {Promise(String)} A promise that resolves with the absolute path to the application
+     */ 
+    getApplicationPath: async function(){ 
+      let libPath = process.cwd(); 
+      if ( ! await fs.existsAsync( path.join( libPath, "compile.json" ) ) ){
+        libPath = path.join( libPath, "demo/default" );
+        if ( ! await fs.existsAsync( path.join( libPath, "compile.json" ) ) ){
+          throw new Error( "Cannot find application path - are you in the right directory?");  
+        }
+      }
+      return libPath;
+    },    
+
+    /**
+     * Return the content of a json file in the library as an object. 
+     * @param {String} filePath absolute path to the file 
+     * @throws {Error} Throws if file cannot be parsed.
+     * @return {Promise(Object)} 
      */
-    parseJsonFile : function(relativePath){
-      let filePath = path.join( this.getLibraryPath(), relativePath );
+    parseJsonFile : async function(filePath){
       try {
-        return JSON.parse( fs.readFileSync( filePath, "utf-8" ) );
+        return JSON.parse( await fs.readFileAsync( filePath, "utf-8" ) );
       } catch(e) {
         throw new Error(`Cannot parse ${filePath}:` + e.message );
       }
@@ -75,29 +93,56 @@ qx.Class.define("qxcli.commands.Command", {
     /**
      * Returns the content of the Manifest.json file as an object. 
      * @throws {Error} Throws if library cannot be found or file cannot be parsed.
-     * @return {Object}
+     * @return {Promise(Object)}
      */    
-    parseManifest : function(){
-      return this.parseJsonFile("Manifest.json");
+    parseManifest : async function(){
+      let manifestPath = path.join( await this.getLibraryPath(), "Manifest.json" );
+      return await this.parseJsonFile(manifestPath);
     },
 
     /**
-     * Returns the content of the compile.json file as an object. Will look into
-     * the demo/default/ directory since contrib libraries often do not have a
-     * compile.json file (since they are meant to be included in other applications).
-     * @throws {Error} Throws if library cannot be found or file cannot be parsed.
-     * @return {Object} The compile configuration data
+     * Returns the content of the compile.json file as an object. 
+     * @throws {Error} Throws if application cannot be found or file cannot be parsed.
+     * @return {Promise(Object)} The compile configuration data
      */    
-    parseCompileConfig : function(){
-      try {
-        return this.parseJsonFile("compile.json");
-      } catch( e ) {
-        return this.parseJsonFile("demo/default/compile.json");
-      }
+    parseCompileConfig : async function(){
+      let compileJsonPath = path.join( await this.getApplicationPath(), "compile.json" )
+      return await this.parseJsonFile(compileJsonPath);
     },
 
     /**
-     * Returns the path to the qooxdoo framework used by the current project
+     * Returns the absolute path to the qooxdoo framework used by the current project
+     * @return {Promise(String)|false} Promise that resolves with the path {String} or false 
+     * if no path can be determined. 
+     */
+    getAppQxPath : async function(){
+      let compileConfig = await this.parseCompileConfig();
+      let qxpath = compileConfig.libraries.find( async (somepath) => {
+        let manifest = await this.parseJsonFile( path.join( somepath, "Manifest.json") );
+        try{
+          return manifest.provides.namespace === "qx";
+        } catch(e) {
+          throw new Error(`Invalid manifest file in ${somepath}.`);
+        }
+      });
+      return path.resolve(qxpath);
+    },
+
+
+    /**
+     * Returns the absolute path to the qooxdoo framework used by the current project, unless
+     * the user provided an option "qxpath" in the argv Map, in which case this value is returned.
+     * @return {Promise(String)|false} Promise that resolves with the absolute path {String} or false 
+     * if no path can be determined. 
+     */    
+    getUserQxPath : async function(argv={}){
+      let qxpath = (argv.qxpath !== undefined) ? argv.qxpath : await this.getAppQxPath();
+      return path.isAbsolute(qxpath) ? qxpath : path.resolve( qxpath );
+    },
+
+    /**
+     * Returns the path to the qooxdoo framework used by the current project. To be replaced by
+     * getUserQxPath()
      * @return {Promise} Promise that resolves with the path {String}
      */
     getQooxdooPath : async function(argv)
@@ -134,7 +179,7 @@ qx.Class.define("qxcli.commands.Command", {
 
     /**
      * Force exit a CLI command, displaying an error message. Better than
-     * throwing exceptionb when stack trace is redundant. 
+     * throwing exceptions when stack trace is redundant. 
      * @param {String} message
      */
     exit : function(message){

--- a/lib/qxcli/commands/Command.js
+++ b/lib/qxcli/commands/Command.js
@@ -43,6 +43,60 @@ qx.Class.define("qxcli.commands.Command", {
     argv: null,
 
     /**
+     * Returns the  path to the current library, depending on the current
+     * working directory. A library is assumed if a Manifest.json file
+     * exists. 
+     * @throws {Error} Throws an error if no library can be found.
+     * @return {String} The absolute path to the library
+     */ 
+    getLibraryPath: function(){ 
+      let libPath = process.cwd(); 
+      if ( ! fs.existsSync( path.join( libPath, "Manifest.json" ) ) ){
+        throw new Error( "Cannot find library - are you in the right directory?");
+      }
+      return libPath;
+    },
+
+    /**
+     * Returns the content of a json file in the library as an object. 
+     * @param {String} Relative path of the file in the library
+     * @throws {Error} Throws if library cannot be found or file cannot be parsed.
+     * @return {Object}
+     */
+    parseJsonFile : function(relativePath){
+      let filePath = path.join( this.getLibraryPath(), relativePath );
+      try {
+        return JSON.parse( fs.readFileSync( filePath, "utf-8" ) );
+      } catch(e) {
+        throw new Error(`Cannot parse ${filePath}:` + e.message );
+      }
+    },
+
+    /**
+     * Returns the content of the Manifest.json file as an object. 
+     * @throws {Error} Throws if library cannot be found or file cannot be parsed.
+     * @return {Object}
+     */    
+    parseManifest : function(){
+      return this.parseJsonFile("Manifest.json");
+    },
+
+    /**
+     * Returns the content of the compile.json file as an object. Will look into
+     * the demo/default/ directory since contrib libraries often do not have a
+     * compile.json file (since they are meant to be included in other applications).
+     * @throws {Error} Throws if library cannot be found or file cannot be parsed.
+     * @return {Object} The compile configuration data
+     */    
+    parseCompileConfig : function(){
+      try {
+        return this.parseJsonFile("compile.json");
+      } catch( e ) {
+        return this.parseJsonFile("demo/default/compile.json");
+      }
+    },
+
+    /**
      * Returns the path to the qooxdoo framework used by the current project
      * @return {Promise} Promise that resolves with the path {String}
      */
@@ -68,7 +122,7 @@ qx.Class.define("qxcli.commands.Command", {
         throw new Error(`Unsupported version number "${qooxdoo_version}. Please use semver compatible version strings."`);
       }
       return qooxdoo_version;
-    },    
+    },
   
     /**
      * Method that is called to do the actual work of the subclass.

--- a/lib/qxcli/commands/Command.js
+++ b/lib/qxcli/commands/Command.js
@@ -117,15 +117,18 @@ qx.Class.define("qxcli.commands.Command", {
      */
     getAppQxPath : async function(){
       let compileConfig = await this.parseCompileConfig();
-      let qxpath = compileConfig.libraries.find( async (somepath) => {
-        let manifest = await this.parseJsonFile( path.join( somepath, "Manifest.json") );
+      let qxpath = false;
+      let appPath = await this.getApplicationPath();
+      for( let somepath of compileConfig.libraries ){
+        let manifestPath = path.join( appPath, somepath, "Manifest.json");
+        let manifest = await this.parseJsonFile( manifestPath );
         try{
-          return manifest.provides.namespace === "qx";
+          if( ! qxpath && manifest.provides.namespace === "qx" ) qxpath = somepath;
         } catch(e) {
-          throw new Error(`Invalid manifest file in ${somepath}.`);
+          throw new Error(`Invalid manifest file ${manifestPath}.`);
         }
-      });
-      return path.resolve(qxpath);
+      };
+      return path.join(appPath,qxpath);
     },
 
 

--- a/lib/qxcli/commands/Command.js
+++ b/lib/qxcli/commands/Command.js
@@ -150,7 +150,7 @@ qx.Class.define("qxcli.commands.Command", {
      */
     getQooxdooPath : async function(argv)
     {
-      return this.getUserQxPath(argv);
+      return await this.getUserQxPath(argv);
       //const cfg_path = path.join(process.cwd(), 'compile.json');
       //let maker = await new qxcli.commands.Compile(argv).configure(cfg_path);
       //return maker.getAnalyser().getQooxdooPath();


### PR DESCRIPTION
Adds three methods on which the command methods can build to get info on the current library/application. Should end the confusion on where the compile.json file is (applications vs. contribs). 