### PR TITLE
Make use of the qooxdoo.json file to configure file locations

### DIFF
--- a/docs/contrib.md
+++ b/docs/contrib.md
@@ -11,6 +11,8 @@
     - [Create a new contrib library project](#create-a-new-contrib-library-project)
     - [Publish new versions of contrib libraries](#publish-new-versions-of-contrib-libraries)
     - [How to list get your contrib repository listed with `qx contrib list`](#how-to-list-get-your-contrib-repository-listed-with-qx-contrib-list)
+        - [qooxdoo.json](#qooxdoojson)
+        - [Contribution compatibility management](#contribution-compatibility-management)
 
 <!-- /TOC -->
 
@@ -162,24 +164,47 @@ push it to the master branch before releasing the new version.
   following ways:
   
   a) If the repository contains just **one single library**, its 
-  `Manifest.json` file **should** be placed in the repository's root 
-  directory. 
+  `Manifest.json` file must be placed in the repository's root 
+  directory (unless you use `qoodoo.json`, see below)
   
   b) If you ship **several libraries** in one repository, or you 
   want to place the `Manifest.json` file outside of the root directory, you 
-  **must** provide a `qooxdoo.json` file in the root dir. This file has the 
-  following syntax: 
+  must provide a `qooxdoo.json` file in the root dir (see below)
+
+- Make sure to keep the "qooxdoo-version" key up to date.
+
+### qooxdoo.json
+
+It is recommended, but not mandatory, to include a `qooxdoo.json` file in the 
+root of the repository. This metadata file allows the discovery of libraries 
+and applications/demos in a repository. It has the  following syntax: 
      
- ```
- {
-   "contribs": [
-    { "path":"./path/to/dir-containing-manifest1" },
-    { "path":"./path/to/dir-containing-manifest2" },
+```
+{
+  "libraries": [
+   { "path":"relative-path/to/dir-containing-manifest1" },
+   { "path":"relative-path/to/dir-containing-manifest2" },
+   ...
+ ],
+  "applications": [
+	  { "path": "relative-path/to/demo1"},
     ...
-  ]
+	]
+}
+``` 
+
+If you do not include the file, the following paths are assumed (for a contrib)
+
+````
+{
+	"libraries": [
+		{ "path": "." }
+	],
+	"applications": [
+		{ "path": "demo/default"}
+	]
 }
 ```
-- Make sure to keep the "qooxdoo-version" key up to date (see below)
 
 ### Contribution compatibility management
 

--- a/lib/qxcli/commands/Command.js
+++ b/lib/qxcli/commands/Command.js
@@ -45,36 +45,61 @@ qx.Class.define("qxcli.commands.Command", {
     argv: null,
 
     /**
-     * Returns the  path to the current library, depending on the current
-     * working directory. A library is assumed if a Manifest.json file
-     * exists. 
+     * Returns data on the project in which the CLI commands are executed. If a qooxdoo.json file 
+     * exists, the data is taken from there. If not, it tries the following: 1) If a Manifest.json
+     * exists in the current dir, it is assumed to be the main library dir. 2) if a compile.json
+     * file exists in the current dir, it is assumed to be the application dir 3) if not, 
+     * the subdir demo/default is checked for a compile.json file. 
+     * @return {Promise(Object)} A promise that resolves to a map containing the following keys:
+     * 'libraries': an array of maps containing a 'path' property with a relative path to a library folder,
+     * 'applications': an array of maps containing a 'path' property with a realtive path to an
+     * application folder. If no project data can be determined, resolves to an empty map. 
+     */
+    getProjectData : async function(){
+      let qooxdooJsonPath = path.join( process.cwd(), "qooxdoo.json" );
+      let data = {};
+      if ( await fs.existsAsync( qooxdooJsonPath ) ){
+        data = await this.parseJsonFile(qooxdooJsonPath);
+      }  else {
+        if ( await fs.existsAsync( path.join( process.cwd(), "Manifest.json" ) ) ){
+          data.libraries = [{ path : "." }];
+        }
+        if ( await fs.existsAsync( path.join( process.cwd(), "compile.json" ) ) ){
+          data.applications = [{ path : "." }];
+        } else if ( await fs.existsAsync( path.join( process.cwd(), "demo/default/compile.json" ) ) ){
+          data.applications = [{ path : "demo/default" }];
+        }
+      }
+      return data; 
+    },
+
+    /**
+     * Returns the path to the current library. If the current directory contains several libraries,
+     * the first one found is returned. 
      * @throws {Error} Throws an error if no library can be found.
      * @return {Promise(String)} A promise that resolves with the absolute path to the library
      */ 
     getLibraryPath: async function(){ 
-      let libPath = process.cwd(); 
-      if ( ! await fs.existsAsync( path.join( libPath, "Manifest.json" ) ) ){
-        throw new qxcli.Utils.UserError( "Cannot find library path - are you in the right directory?");
+      let {libraries} = await this.getProjectData();
+      if( libraries instanceof Array && libraries.length ) {
+        return path.resolve( process.cwd(), libraries[0].path );
       }
-      return libPath;
+      throw new qxcli.Utils.UserError( "Cannot find library path - are you in the right directory?");
     },
 
     /**
-     * Returns the  path to the cu  rrent application, depending on the current
-     * working directory. An application is assumed if a compile.json file
-     * exists. 
+     * Returns the path to the current application, depending on the current
+     * working directory. If a directory contains several applications, the first one found is 
+     * returned. 
      * @throws {Error} Throws an error if no application can be found.
      * @return {Promise(String)} A promise that resolves with the absolute path to the application
      */ 
     getApplicationPath: async function(){ 
-      let libPath = process.cwd(); 
-      if ( ! await fs.existsAsync( path.join( libPath, "compile.json" ) ) ){
-        libPath = path.join( libPath, "demo/default" );
-        if ( ! await fs.existsAsync( path.join( libPath, "compile.json" ) ) ){
-          throw new qxcli.Utils.UserError( "Cannot find application path - are you in the right directory?");  
-        }
+      let {applications} = await this.getProjectData();
+      if( applications instanceof Array && applications.length ) {
+        return path.resolve( process.cwd(), applications[0].path );
       }
-      return libPath;
+      throw new qxcli.Utils.UserError( "Cannot find application path - are you in the right directory?");  
     },    
 
     /**
@@ -123,7 +148,7 @@ qx.Class.define("qxcli.commands.Command", {
       for( let somepath of compileConfig.libraries ) {
         let manifestPath = somepath;
         if (!path.isAbsolute(somepath)) {
-          let manifestPath = path.join( appPath, manifestPath);
+          manifestPath = path.join( appPath, manifestPath);
         }
         manifestPath = path.join( manifestPath, "Manifest.json");
         let manifest = await this.parseJsonFile( manifestPath );

--- a/lib/qxcli/commands/contrib/Update.js
+++ b/lib/qxcli/commands/contrib/Update.js
@@ -186,7 +186,7 @@ qx.Class.define("qxcli.commands.contrib.Update", {
               }
               // we have a list of Manifest.json paths!
               if (data.contribs && data.contribs instanceof Array) {
-                manifests = data.contribs;
+                manifests = data.libraries || data.contribs; // data.contribs is deprecated
               }            
             } catch (e) {
               // no Qooxdoo.json

--- a/templates/skeleton/contrib/qooxdoo.json
+++ b/templates/skeleton/contrib/qooxdoo.json
@@ -1,0 +1,8 @@
+{
+	"libraries": [
+		{ "path": "." }
+	],
+	"applications": [
+		{ "path": "demo/default"}
+	]
+}


### PR DESCRIPTION
**Do not vote on or merge this yet - preview/RFC without enough testing**

This is the missing piece of the puzzle in the "architecture" of qooxdoo contrib that formalizes some of the implicit conventions (aka "automagic") of the system. 

Contribs should have a default `qooxdoo.json` file which specifies where the libraries and the applications of the contrib are located. This file can be omitted, however, then the default values kick in (library in `.` and demo application in `demo/default`). This ensures that libraries and applications can be discovered automatically - the libraries for inclusion in other projects, tests and demos for testrunners/demobrowsers etc. 

