### PR TITLE
Insert newline to avoid overwrite

### DIFF
--- a/lib/qxcli/commands/Compile.js
+++ b/lib/qxcli/commands/Compile.js
@@ -180,7 +180,7 @@ qx.Class.define("qxcli.commands.Compile", {
         qxcompiler.Console.getInstance().setWriter((str, msgId) => { 
           msgId = qxcompiler.Console.MESSAGE_IDS[msgId];
           if (msgId.type !== "message")
-            console.log(TYPES[msgId.type] + ": " + str);
+            console.log('\n' + TYPES[msgId.type] + ": " + str);
           else
             this.__gauge.show(str); 
         });


### PR DESCRIPTION
A very extensive PR which adds a newline to avoid messages like

```
ERROR: Cannot write application 'foo' because it has fatal errorsr
```

where the error message overwrites the former *gauge* output.