### PR TITLE
Fixes #78: ignored properties defaultTarget and minification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ qooxdoo
 foo
 .contrib-cache.json
 myapp
+*~

--- a/docs/compile-json.md
+++ b/docs/compile-json.md
@@ -56,7 +56,7 @@ The `applications` key is an array of objects, and each object can contain:
 - `type` - (**optional**, **advanced**) this is "browser" (the default) for the typical, web browser based, application or "node" for a node.js server
 application.
 `loaderTemplate` - (**optional**, **advanced**) this is the boot loader template file, usually determined automatically from the application `type` 
-`minification` - (**optional**) determines the minification to be used for this application, if the target supports it; overrides other settings.  Can be `none`, `minify`, or `mangle`
+`minify` - (**optional**) determines the minification to be used for this application, if the target supports it; overrides other settings.  Can be `off`, `minify`, `mangle` or `beautify`; takes precedence over the target's `minify` setting.
 
 A complete example is:
 ```
@@ -85,7 +85,7 @@ The `targets` key is an array of objects, one for each possible target that can 
 - `writeCompileInfo` (**optional**) if true, the target will write a `compile-info.json` and `resources.json` into the application's output directory, containing the data structures required to generate an application
 - `uri` (**optional**) the URI used to load resources for this target; by default, this is assumed to be relative to the application's index.html
 - `typescript` - see below
-- `minification` - (**optional**) determines the minification to be used for applications, if the target supports it; can be overridden on a per application basis.  Can be `none`, `minify`, or `mangle`
+- `minify` - (**optional**) determines the minification to be used for applications, if the target supports it; can be overridden on a per application basis.  Can be `off`, `minify`, `mangle`, or `beautify`.
 - `addCreatedAt` - (**optional**) if true, this will cause every object to have a hidden property called `$$createdAt` which points to an object containing `filename`, `lineNumber`, and `column` properties
 
 ## Parts

--- a/lib/qxcli/commands/Compile.js
+++ b/lib/qxcli/commands/Compile.js
@@ -52,8 +52,7 @@ qx.Class.define("qxcli.commands.Compile", {
             type: "boolean"
           },
           "target": {
-            "default": "source",
-            describe: "Set the target type: source, build, hybrid or class name",
+            describe: "Set the target type: source, build, hybrid or class name. Default is first target in config file",
             requiresArg: true,
             type: "string"
           },
@@ -256,7 +255,7 @@ qx.Class.define("qxcli.commands.Compile", {
             }
           }
           if (!config.target) {
-            if (config.targets.length == 1)
+            if (config.targets.length > 0)
               config.target = config.targets[0];
           }
 


### PR DESCRIPTION
The defaultTarget property was forced to 'source' by its default value in the
yargs configuration. The implementation has now been changed. The default
value, if not provided either in the defaultTarget setting in the compile.json
file, or on the command line, is to use the first target listed in compile.json.

The ignored minification was a documentation error. The correct key is `minify`.

This commit also adds emacs backup files to the list of ignored files in
.gitignore.