### PR TITLE
Manifest doc

### DIFF
--- a/docs/Manifest.md
+++ b/docs/Manifest.md
@@ -1,0 +1,84 @@
+# Manifest.json
+
+qooxdoo's [Manifest files](http://en.wikipedia.org/wiki/Manifest_file) serve to provide meta information for a library in a structured way. Their syntax is in JSON. They have a more informational part (keyed `info`), which is more interesting for human readers, a technical part (named `provides`) that is used in the processing of generator configurations, and a part named `externalResources` to include CSS and Javascript files. Here is a brief sample with all the possible keys:
+
+Manifest files are referenced in application's *config.json* files (in the library), to identify the library they stand for.
+
+## Reference
+
+This is a sample file:
+
+```json
+{
+  "info" : 
+  {
+    "name" : "Custom Application",
+
+    "summary" : "Custom Application",
+    "description" : "This is a skeleton for a custom application with qooxdoo.",
+
+    "keywords" : ["custom"],
+    "homepage" : "http://some.homepage.url/",
+
+    "license" : "SomeLicense",
+    "authors" : 
+    [
+      {
+        "name" : "First Author (uid)",
+        "email" : "first.author@some.domain"
+      }
+    ],
+
+    "version" : "trunk",
+    "qooxdoo-versions": ["trunk"],
+    "sourceViewUri" : "https://github.com/someuser/custom/blob/master/source/class/%{classFilePath}#L%{lineNumber}"
+  },
+
+  "provides" : 
+  {
+    "namespace"   : "custom",
+    "encoding"    : "utf-8",
+    "class"       : "source/class",
+    "resource"    : "source/resource",
+    "translation" : "source/translation",
+    "type"        : "application"
+  },
+
+  "externalResources" :
+  {
+    "script": [
+      "js/customscript.js",
+    ],
+    "css": [
+      "styles/style.css"
+    ]
+  }
+}
+```
+
+## Description of Keys
+
+* **info**: All entries in this section are optional.
+  * **name**: Name of the library.
+  * **summary**: Short summary of its purpose.
+  * **description**: Descriptive text.
+  * **keywords**: List of keywords, tags.
+  * **homepage**: Homepage URL of the library.
+  * **license**: License name(s) of the library.
+  * **authors**: Author(s) of the library. A list of maps, each map containing the following fields:
+    * **name** : Author name.
+    * **email** : Author email address.
+  * **version**: Version of  the library.
+  * **qooxdoo-versions**: List of versions of the qooxdoo framework this library is compatible with.
+  * **sourceViewUri**: URL to view the library's class code online. This URL will be used in generated API documentation. It has a special syntax and allows for placeholders (e.g. for the class name and the source line number).
+* **provides**: Entries in this section are mandatory.
+  * **namespace**: Library namespace (i.e. the namespace elements all class names in this library are prefixed with, e.g. `foo` for a main application class with name `foo.Application`).
+  * **encoding**: File encoding of source code files (should be utf-8).
+  * **class**: Path to the library's class code relative to the Manifest.json file, up to but not including the root namespace folder (e.g. `source/class`).
+  * **resource**: Path to the library's resources relative to the Manifest.json file, up to but not including the root namespace folder (e.g. `source/resource`).
+  * **translation**: Path to the library's translation files relative to the Manifest.json file (e.g. `source/translation`).
+  * **type**: One of [`library`, `application`].
+* **externalResources**: Static Javascript and CSS files that shall be always included without further processing by qooxdoo. All paths are relative to the resource folder stated in the "provides" section.
+  * **script**: Array of javascript files.
+  * **css**: Array of css files.
+

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ This command line utility allows you create, build and manage [qooxdoo](http://w
         - [Compiler](#compiler)
         - [Create a new project](#create-a-new-project)
         - [qooxdoo-contrib system](#qooxdoo-contrib-system)
-        - [Manifest.json](#manifest.json)
+        - [Manifest.json](#manifestjson)
 
 <!-- /TOC -->
 
@@ -189,9 +189,6 @@ To provide additional information and configuration for qooxdoo libraries the fi
 
 ```json
 {
-  // "info" : { ... },
-  // "provides" : { ... },
-
   "externalResources" :
   {
     "script": [

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,7 @@ This command line utility allows you create, build and manage [qooxdoo](http://w
         - [Compiler](#compiler)
         - [Create a new project](#create-a-new-project)
         - [qooxdoo-contrib system](#qooxdoo-contrib-system)
+        - [Manifest.json](#manifest.json)
 
 <!-- /TOC -->
 
@@ -182,3 +183,23 @@ Commands:
 Please see the detailed documentation [here](docs/contrib.md).
 
 
+### Manifest.json
+
+To provide additional information and configuration for qooxdoo libraries the file `Manifest.json` can be used - just like with the old python tool chain. A small difference is the added option to add static javascript and stylesheet files which will automatically be loaded into the application. Please refer to the [detailed documentation](docs/Manifest.md) for further information. Here is a shortened example of how to add static files:
+
+```json
+{
+  // "info" : { ... },
+  // "provides" : { ... },
+
+  "externalResources" :
+  {
+    "script": [
+      "js/customscript.js",
+    ],
+    "css": [
+      "styles/style.css"
+    ]
+  }
+}
+```


### PR DESCRIPTION
Converted the documentation for Manifest.json from rst to markdown, added documentation for external resources and a reference in readme.md.

It was mentioned in https://github.com/qooxdoo/qooxdoo/pull/9479 to put it here. 

This pr is for #16 