### PR TITLE
Delete CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @johnspackman @cboulanger @hkollmann


### PR DESCRIPTION
This is no longer necessary because this is a deprecated repo (merged into qooxdoo-compiler)